### PR TITLE
Redecrypt ciphertext on a dirty form

### DIFF
--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -15,13 +15,9 @@ const defaultProps = {
 }
 
 export const TextArea = (props: TextAreaProps) =>
-    <label
-        htmlFor={props.label}
-        className="form-label p-0"
-    >
+    <label className="form-label p-0">
         {props.label}
         <textarea
-            id={props.label}
             className="form-control"
             cols={props.cols ?? defaultProps.cols}
             rows={props.rows ?? defaultProps.rows}

--- a/src/views/MultiDecrypt.tsx
+++ b/src/views/MultiDecrypt.tsx
@@ -10,7 +10,7 @@ import {downloadFile} from "../actions/file-utils"
 export const MultiDecrypt = () => {
     const [ciphertext, setCiphertext] = useState("")
     const [content, setContent] = useState<DecryptionContent>()
-    const [error, setError] = useState(() => "")
+    const [error, setError] = useState("")
     const [isLoading, setIsLoading] = useState(false)
     const [dirtyForm, setDirtyForm] = useState(false)
 
@@ -28,7 +28,7 @@ export const MultiDecrypt = () => {
         setIsLoading(true)
 
         // for some reason all the state updates don't happen without `setTimeout`
-        setTimeout(() => decryptMulti(ciphertext)
+        const ongoingDecryption = setTimeout(() => decryptMulti(ciphertext)
                 .then(c => setContent(c))
                 .catch(err => {
                     console.error(err)
@@ -39,6 +39,8 @@ export const MultiDecrypt = () => {
                     setDirtyForm(false)
                 }),
             0)
+
+        return () => clearTimeout(ongoingDecryption)
     }, [ciphertext, dirtyForm])
 
     return (

--- a/src/views/MultiDecrypt.tsx
+++ b/src/views/MultiDecrypt.tsx
@@ -29,16 +29,16 @@ export const MultiDecrypt = () => {
 
         // for some reason all the state updates don't happen without `setTimeout`
         const ongoingDecryption = setTimeout(() => decryptMulti(ciphertext)
-                .then(c => setContent(c))
-                .catch(err => {
-                    console.error(err)
-                    setError(localisedDecryptionMessageOrDefault(err))
-                })
-                .finally(() => {
-                    setIsLoading(false)
-                    setDirtyForm(false)
-                }),
-            0)
+            .then(c => setContent(c))
+            .catch(err => {
+                console.error(err)
+                setError(localisedDecryptionMessageOrDefault(err))
+            })
+            .finally(() => {
+                setIsLoading(false)
+                setDirtyForm(false)
+            })
+        )
 
         return () => clearTimeout(ongoingDecryption)
     }, [ciphertext, dirtyForm])


### PR DESCRIPTION
If your ciphertext failed to decrypt because the decryption time hadn't
been met, waiting and repasting it would not decrypt due to preact
comparing the ciphertext values and not re-rendering

Also moved the settimeout shenanigans around to guarantee error messages
appearing